### PR TITLE
Add option for additional labels and annotations to chart

### DIFF
--- a/helm/vbump/templates/deployment.yaml
+++ b/helm/vbump/templates/deployment.yaml
@@ -7,6 +7,15 @@ metadata:
     helm.sh/chart: {{ include "vbump.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.deployment.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.deployment.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +27,15 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "vbump.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- range $key, $value := .Values.deployment.pod.labels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if .Values.deployment.pod.annotations }}
+      annotations:
+        {{- range $key, $value := .Values.deployment.pod.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
     spec:
     {{- if .Values.persistence.enabled }}
       volumes:

--- a/helm/vbump/templates/service.yaml
+++ b/helm/vbump/templates/service.yaml
@@ -7,6 +7,15 @@ metadata:
     helm.sh/chart: {{ include "vbump.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.service.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/vbump/values.yaml
+++ b/helm/vbump/values.yaml
@@ -9,12 +9,21 @@ image:
   tag: 1.3.0
   pullPolicy: Always
 
+deployment:
+  labels: {}
+  annotations: {}
+  pod:
+    labels: {} 
+    annotations: {}
+
 nameOverride: ""
 fullnameOverride: ""
 
 service:
   type: ClusterIP
   port: 80
+  labels: {}
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Since we are not able to adjust labels and annotations from service, deployment, pod etc its kind of hard to get vbump into monitoring.
This PR should make it possible to set labels for servicemonitors or annotations for old prometheus style discovery.
